### PR TITLE
Remove legacy facts

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -72,7 +72,7 @@ class cerebro::install (
   }
 
 
-  if ($::operatingsystem == 'Amazon') {
+  if ($facts['os']['name'] == 'Amazon') {
     file { '/etc/init.d/cerebro':
       content => template('cerebro/etc/init.d/cerebro.erb'),
       mode    => '0744',

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -21,7 +21,7 @@ class cerebro::params {
   $basic_auth_settings        = undef
   $ldap_auth_settings         = undef
   $ldap_group_search_settings = undef
-  $sysconfig = $::osfamily ? {
+  $sysconfig = $facts['os']['family'] ? {
     'Debian' => '/etc/default/cerebro',
     default  => '/etc/sysconfig/cerebro',
   }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -2,7 +2,7 @@ class cerebro::service (
   $ensure = $::cerebro::service_ensure,
   $enable = $::cerebro::service_enable,
 ) {
-  if ($::operatingsystem == 'Amazon') {
+  if ($facts['os']['name'] == 'Amazon') {
     service { 'cerebro':
       ensure  => $ensure,
       enable  => $enable,


### PR DESCRIPTION
A quick PR to remove legacy facts in order to support Puppet 8.